### PR TITLE
feat: enable instantiable clients

### DIFF
--- a/lib/chargebee.js
+++ b/lib/chargebee.js
@@ -17,6 +17,27 @@ ChargeBee.configure = function(conf) {
     ChargeBee._util.extend(true, ChargeBee._env, conf);
 };
 
+ChargeBee.Client = function(options) {
+    options = options || {};
+    if (typeof(options['api_key']) !== 'string') {
+        throw new Error('cannot instantiate client without an "api_key".')
+    } else if (typeof(options['site']) !== 'string') {
+        throw new Error('cannot instantiate client without a "site".')
+    }
+    var conf = {
+        site: options.site,
+        api_key: options.api_key
+    };
+    for (var res in ChargeBee._endpoints) {
+        this[res] = {};
+        var apiCalls = ChargeBee._endpoints[res];
+        for (var apiIdx = 0; apiIdx < apiCalls.length; apiIdx++) {
+          var apiCall = getApiCall(apiCalls[apiIdx]);
+          this[res][apiCall.methodName] = createApiFunc(apiCall, conf);
+        }
+    }
+};
+
 ChargeBee._endpoints = require('./resources/api_endpoints.js');
 
 
@@ -106,16 +127,19 @@ ChargeBee._waitForExport = function(exportId){
 }
 
 
-function createApiFunc(apiCall) {
+function createApiFunc(apiCall, conf) {
     return function() {
-        return new RequestWrapper(arguments, apiCall);
+        return new RequestWrapper(arguments, apiCall, conf);
     };
 }
 
-function RequestWrapper(args, apiCall) {
+function RequestWrapper(args, apiCall, conf) {
     this.args = args;
     this.httpHeaders = {};
     this.apiCall = apiCall;
+    if(typeof(conf) !== 'undefined') {
+      this.conf = conf;
+    }
     if (this.apiCall.hasIdInUrl) {
         validateIdParam(this.args[0]);
     }
@@ -127,7 +151,7 @@ RequestWrapper.prototype.headers = function(headers) {
 };
 
 RequestWrapper.prototype.request = function(callBack, envOptions) {
-    var env = {};
+    var env = this.conf || {};
     var jsonConstructor =  {}.constructor;
     ChargeBee._util.extend(true, env, ChargeBee._env);
     if (typeof envOptions !== 'undefined') {
@@ -296,7 +320,7 @@ ChargeBee._core = (function() {
                 if(value !== null) {
                     attrVal = encodeURIComponent(Object.prototype.toString.call(value) === "[object String]" ? ChargeBee._util.trim(value) : JSON.stringify(value));
                 }
-                serialized.push(encodeURIComponent(key) + "=" + attrVal);    
+                serialized.push(encodeURIComponent(key) + "=" + attrVal);
             } else if (typeof value === 'object' && !ChargeBee._util.isArray(value)) {
                 encodeParams(value, serialized, key);
             } else {
@@ -437,19 +461,24 @@ ChargeBee._util = (function() {
 
 }).call(this);
 
+function getApiCall(apiCallObj) {
+  var metaArr = apiCallObj;
+  return {"methodName": metaArr[0],
+    "httpMethod": metaArr[1],
+    "urlPrefix": metaArr[2],
+    "urlSuffix": metaArr[3],
+    "hasIdInUrl": metaArr[4],
+    "isListReq": metaArr[0]==="list"};
+}
+
 (function() {
     module.exports.configure = ChargeBee.configure;
+    module.exports.Client = ChargeBee.Client;
     for (var res in ChargeBee._endpoints) {
         module.exports[res] = {};
         var apiCalls = ChargeBee._endpoints[res];
         for (var apiIdx = 0; apiIdx < apiCalls.length; apiIdx++) {
-            var metaArr = apiCalls[apiIdx];
-            var apiCall = {"methodName": metaArr[0],
-                "httpMethod": metaArr[1],
-                "urlPrefix": metaArr[2],
-                "urlSuffix": metaArr[3],
-                "hasIdInUrl": metaArr[4],
-                "isListReq": metaArr[0]==="list"};
+            var apiCall = getApiCall(apiCalls[apiIdx]);
             module.exports[res][apiCall.methodName] = createApiFunc(apiCall);
         }
     }


### PR DESCRIPTION
Re: https://github.com/chargebee/chargebee-node/issues/11

**Use Case**

Allow multi-tenanted client configurations at the point of initialization. Separates the concern of client environment setup (i.e. providing API keys) from that of making business requests.

**Example Usage**:

```javascript
const chargebee = require("chargebee");

...
const client = new chargebee.Client({ site: SITE, api_key: tenant.getCbApiKey() });
const result = await client.subscription.create(DATA).request();
...

```