### PR TITLE
Removing deprecated call to Buffer

### DIFF
--- a/lib/chargebee.js
+++ b/lib/chargebee.js
@@ -219,7 +219,7 @@ ChargeBee._core = (function() {
         var data = encodeParams(params);
         var protocol = (env.protocol === 'http' ? http : https);
         ChargeBee._util.extend(true, headers, {
-            'Authorization': 'Basic ' + new Buffer(env.api_key + ':').toString('base64'),
+            'Authorization': 'Basic ' + Buffer.from(env.api_key + ':', "base64").toString('base64'),
             'Accept': 'application/json',
             'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
             "Content-Length": data.length,


### PR DESCRIPTION
The call, as is is deprecated, and throws warnings. Adding an equivalent static call without the warnings.