### PR TITLE
Updating deprecated use of `new Buffer()`

### DIFF
--- a/lib/chargebee.js
+++ b/lib/chargebee.js
@@ -219,7 +219,7 @@ ChargeBee._core = (function() {
         var data = encodeParams(params);
         var protocol = (env.protocol === 'http' ? http : https);
         ChargeBee._util.extend(true, headers, {
-            'Authorization': 'Basic ' + new Buffer(env.api_key + ':').toString('base64'),
+            'Authorization': 'Basic ' + Buffer.from(env.api_key + ':').toString('base64'),
             'Accept': 'application/json',
             'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
             "Content-Length": data.length,


### PR DESCRIPTION
`new Buffer()` has been deprecated for some time, due to security issues:

```
(node:25456) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```