### PR TITLE
Add missing endpoint "checkout_one_time_for_items".

### DIFF
--- a/lib/resources/api_endpoints.js
+++ b/lib/resources/api_endpoints.js
@@ -1158,6 +1158,13 @@ var _endpoints = {
       false
     ],
     [
+      "checkout_one_time_for_items",
+      "POST",
+      "/hosted_pages",
+      "/checkout_one_time_for_items",
+      false
+    ],
+    [
       "checkout_new_for_items",
       "POST",
       "/hosted_pages",


### PR DESCRIPTION
The endpoint `checkout_one_time_for_items` referenced from https://apidocs.chargebee.com/docs/api/hosted_pages?prod_cat_ver=2&lang=node#checkout_charge-items_and_one-time_charges is missing.