### PR TITLE
Specify return type of configure method

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -75,7 +75,7 @@
 
 declare module 'chargebee' {
   export default class {
-    static configure({ site, api_key }: { site: string; api_key: string });
+    static configure({ site, api_key }: { site: string; api_key: string }): void;
     static address: Address.AddressResource;
     static attached_item: AttachedItem.AttachedItemResource;
     static business_entity: BusinessEntity.BusinessEntityResource;


### PR DESCRIPTION
## Description

This Pull Request addresses a critical TypeScript error (TS7010) in the configure method, which lacks a return type annotation and implicitly has an any return type. This is not just a warning; it is an error that prevents TypeScript code from compiling successfully, especially when the noImplicitAny compiler option is enabled.

I have added an explicit void return type to the configure method to resolve this error. This change is essential to ensure that the TypeScript code compiles without issues, which is necessary for the successful deployment of my Google Cloud Function.

## Urgency

Please review and merge this PR as soon as possible to unblock the deployment process. The current compilation error directly impacts our ability to deploy.

This description clearly outlines the issue, the solution, and the urgency, making it easier for the maintainers to understand and prioritize your PR.

## Screenshot

<img width="874" alt="CleanShot 2024-09-02 at 15 13 20@2x" src="https://github.com/user-attachments/assets/461199ca-36a4-4c8c-9e4a-9bd4c2612fd4">