### PR TITLE
Release node SDK v3.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+### v3.11.0 (2025-07-18) 
+* * * 
+
+### New Resources: 
+* BillingConfiguration has been added. 
+* Brand has been added. 
+
+### New Attributes: 
+* has_children has been added to Hierarchy
+* coupon_applicability_mappings has been added to QuotedRamp.
+
+### New Endpoint:
+* listHierarchyDetail has been added to Customer.
+
+### New Input parameters: 
+* change_reason children has been added to Entitlement#CreateRequest.
+* entitlements[apply_grandfathering] has been added to Entitlement#CreateRequest.
+* replace_primary_payment_source has been added to Purchase#CreateRequest.
+* omnichannel_subscription has been added to RecordedPurchase#CreateRequest.
+* contract_term has been added to Subscription#RemoveScheduledCancellationRequest.
+* contract_term_billing_cycle_on_renewal has been added to Subscription#RemoveScheduledCancellationRequest.
+
+### New Enums: 
+* payconiq_by_bancontact has been added to PaymentMethodType.
+* solidgate has been added to Gateway.
+* solidgate has been added to PaymentMethod.
+
 ### v3.10.0 (2025-06-30)
 * * * 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chargebee",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "A library for integrating with Chargebee.",
   "scripts": {
     "prepack": "npm install && npm run build",

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -9,7 +9,7 @@ export const Environment = {
   hostSuffix: '.chargebee.com',
   apiPath: '/api/v2',
   timeout: DEFAULT_TIME_OUT,
-  clientVersion: 'v3.10.0',
+  clientVersion: 'v3.11.0',
   port: DEFAULT_PORT,
   timemachineWaitInMillis: DEFAULT_TIME_MACHINE_WAIT,
   exportWaitInMillis: DEFAULT_EXPORT_WAIT,

--- a/src/resources/api_endpoints.ts
+++ b/src/resources/api_endpoints.ts
@@ -42,6 +42,7 @@ interface Endpoints {
   quotedSubscription: EndpointTuple[];
   quotedCharge: EndpointTuple[];
   quotedRamp: EndpointTuple[];
+  billingConfiguration: EndpointTuple[];
   quoteLineGroup: EndpointTuple[];
   plan: EndpointTuple[];
   addon: EndpointTuple[];
@@ -95,6 +96,7 @@ interface Endpoints {
   usageEvent: EndpointTuple[];
   omnichannelSubscriptionItemScheduledChange: EndpointTuple[];
   usageFile: EndpointTuple[];
+  brand: EndpointTuple[];
 }
 export const Endpoints: Endpoints = {
   subscription: [
@@ -864,6 +866,17 @@ export const Endpoints: Endpoints = {
       },
     ],
     ['hierarchy', 'GET', '/customers', '/hierarchy', true, null, false, {}, {}],
+    [
+      'listHierarchyDetail',
+      'GET',
+      '/customers',
+      '/hierarchy_detail',
+      true,
+      null,
+      false,
+      {},
+      {},
+    ],
     [
       'updateHierarchySettings',
       'POST',
@@ -3035,6 +3048,7 @@ export const Endpoints: Endpoints = {
   quotedSubscription: [],
   quotedCharge: [],
   quotedRamp: [],
+  billingConfiguration: [],
   quoteLineGroup: [],
   plan: [
     [
@@ -4813,4 +4827,5 @@ export const Endpoints: Endpoints = {
       {},
     ],
   ],
+  brand: [],
 };

--- a/types/core.d.ts
+++ b/types/core.d.ts
@@ -409,6 +409,7 @@ declare module 'chargebee' {
     | 'ebanx'
     | 'dlocal'
     | 'nuvei'
+    | 'solidgate'
     | 'paystack'
     | 'jp_morgan'
     | 'gocardless'
@@ -484,7 +485,8 @@ declare module 'chargebee' {
     | 'sepa_instant_transfer'
     | 'automated_bank_transfer'
     | 'klarna_pay_now'
-    | 'online_banking_poland';
+    | 'online_banking_poland'
+    | 'payconiq_by_bancontact';
   type PaymentMethodTypeEnum =
     | 'card'
     | 'paypal_express_checkout'
@@ -509,7 +511,8 @@ declare module 'chargebee' {
     | 'sepa_instant_transfer'
     | 'automated_bank_transfer'
     | 'klarna_pay_now'
-    | 'online_banking_poland';
+    | 'online_banking_poland'
+    | 'payconiq_by_bancontact';
   type PaymentVoucherTypeEnum = 'boleto';
   type PeriodUnitEnum = 'day' | 'week' | 'month' | 'year';
   type PriceTypeEnum = 'tax_exclusive' | 'tax_inclusive';
@@ -600,7 +603,8 @@ declare module 'chargebee' {
     | 'sepa_instant_transfer'
     | 'automated_bank_transfer'
     | 'klarna_pay_now'
-    | 'online_banking_poland';
+    | 'online_banking_poland'
+    | 'payconiq_by_bancontact';
   type UnbilledChargesHandlingEnum = 'no_action' | 'invoice';
   type UnbilledChargesOptionEnum = 'invoice' | 'delete';
   type UnpaidInvoicesHandlingEnum = 'no_action' | 'schedule_payment_collection';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,6 +3,8 @@
 ///<reference path='./resources/AdvanceInvoiceSchedule.d.ts' />
 ///<reference path='./resources/AttachedItem.d.ts' />
 ///<reference path='./resources/Attribute.d.ts' />
+///<reference path='./resources/BillingConfiguration.d.ts' />
+///<reference path='./resources/Brand.d.ts' />
 ///<reference path='./resources/BusinessEntity.d.ts' />
 ///<reference path='./resources/BusinessEntityTransfer.d.ts' />
 ///<reference path='./resources/Card.d.ts' />

--- a/types/resources/BillingConfiguration.d.ts
+++ b/types/resources/BillingConfiguration.d.ts
@@ -1,0 +1,18 @@
+///<reference path='./../core.d.ts'/>
+///<reference path='./../index.d.ts'/>
+
+declare module 'chargebee' {
+  export interface BillingConfiguration {
+    is_calendar_billing_enabled: boolean;
+    billing_dates?: BillingConfiguration.BillingDate[];
+  }
+
+  export namespace BillingConfiguration {
+    export interface BillingDate {
+      start_date?: number;
+      end_date?: number;
+    }
+    // REQUEST PARAMS
+    //---------------
+  }
+}

--- a/types/resources/Brand.d.ts
+++ b/types/resources/Brand.d.ts
@@ -1,0 +1,9 @@
+///<reference path='./../core.d.ts'/>
+///<reference path='./../index.d.ts'/>
+
+declare module 'chargebee' {
+  export interface Brand {
+    id: string;
+    name: string;
+  }
+}

--- a/types/resources/Card.d.ts
+++ b/types/resources/Card.d.ts
@@ -62,6 +62,7 @@ declare module 'chargebee' {
       | 'giropay'
       | 'card'
       | 'latam_local_card'
+      | 'payconiq'
       | 'not_applicable';
     customer_id: string;
     masked_number?: string;

--- a/types/resources/CreditNote.d.ts
+++ b/types/resources/CreditNote.d.ts
@@ -547,7 +547,13 @@ declare module 'chargebee' {
       entity_id?: string;
     }
     export interface LineItemRetrieveInputParam {
+      /**
+       * @deprecated Please refer API docs to use other attributes
+       */
       subscription_id?: filter.String;
+      /**
+       * @deprecated Please refer API docs to use other attributes
+       */
       customer_id?: filter.String;
     }
 

--- a/types/resources/Customer.d.ts
+++ b/types/resources/Customer.d.ts
@@ -224,6 +224,12 @@ declare module 'chargebee' {
         headers?: ChargebeeRequestHeader,
       ): Promise<ChargebeeResponse<HierarchyResponse>>;
 
+      listHierarchyDetail(
+        customer_id: string,
+        input: ListHierarchyDetailInputParam,
+        headers?: ChargebeeRequestHeader,
+      ): Promise<ChargebeeResponse<ListHierarchyDetailResponse>>;
+
       updateHierarchySettings(
         customer_id: string,
         input?: UpdateHierarchySettingsInputParam,
@@ -339,6 +345,11 @@ declare module 'chargebee' {
 
     export interface HierarchyResponse {
       hierarchies: Hierarchy[];
+    }
+
+    export interface ListHierarchyDetailResponse {
+      list: { hierarchies: any[] }[];
+      next_offset?: string;
     }
 
     export interface UpdateHierarchySettingsResponse {
@@ -641,6 +652,14 @@ declare module 'chargebee' {
         | 'subordinates'
         | 'path_to_root';
     }
+    export interface ListHierarchyDetailInputParam {
+      limit?: number;
+      offset?: string;
+      hierarchy_operation_type:
+        | 'complete_hierarchy'
+        | 'subordinates'
+        | 'path_to_root';
+    }
     export interface UpdateHierarchySettingsInputParam {
       use_default_hierarchy_settings?: boolean;
       parent_account_access?: ParentAccountAccessUpdateHierarchySettingsInputParam;
@@ -717,7 +736,8 @@ declare module 'chargebee' {
         | 'faster_payments'
         | 'sepa_instant_transfer'
         | 'klarna_pay_now'
-        | 'online_banking_poland';
+        | 'online_banking_poland'
+        | 'payconiq_by_bancontact';
       reference_id?: string;
       /**
        * @deprecated Please refer API docs to use other attributes
@@ -888,7 +908,8 @@ declare module 'chargebee' {
         | 'faster_payments'
         | 'sepa_instant_transfer'
         | 'klarna_pay_now'
-        | 'online_banking_poland';
+        | 'online_banking_poland'
+        | 'payconiq_by_bancontact';
       /**
        * @deprecated Please refer API docs to use other attributes
        */

--- a/types/resources/Entitlement.d.ts
+++ b/types/resources/Entitlement.d.ts
@@ -54,6 +54,7 @@ declare module 'chargebee' {
     }
     export interface CreateInputParam {
       action: ActionEnum;
+      change_reason?: string;
       entitlements?: EntitlementsCreateInputParam[];
     }
     export interface EntitlementsCreateInputParam {
@@ -61,6 +62,7 @@ declare module 'chargebee' {
       feature_id: string;
       entity_type?: 'plan' | 'addon' | 'charge' | 'plan_price' | 'addon_price';
       value?: string;
+      apply_grandfathering?: boolean;
     }
   }
 }

--- a/types/resources/Estimate.d.ts
+++ b/types/resources/Estimate.d.ts
@@ -1034,7 +1034,8 @@ declare module 'chargebee' {
         | 'faster_payments'
         | 'sepa_instant_transfer'
         | 'klarna_pay_now'
-        | 'online_banking_poland';
+        | 'online_banking_poland'
+        | 'payconiq_by_bancontact';
       reference_id?: string;
       /**
        * @deprecated Please refer API docs to use other attributes
@@ -1111,7 +1112,8 @@ declare module 'chargebee' {
         | 'faster_payments'
         | 'sepa_instant_transfer'
         | 'klarna_pay_now'
-        | 'online_banking_poland';
+        | 'online_banking_poland'
+        | 'payconiq_by_bancontact';
       reference_id?: string;
       /**
        * @deprecated Please refer API docs to use other attributes

--- a/types/resources/Gift.d.ts
+++ b/types/resources/Gift.d.ts
@@ -200,7 +200,8 @@ declare module 'chargebee' {
         | 'faster_payments'
         | 'sepa_instant_transfer'
         | 'klarna_pay_now'
-        | 'online_banking_poland';
+        | 'online_banking_poland'
+        | 'payconiq_by_bancontact';
       reference_id?: string;
       /**
        * @deprecated Please refer API docs to use other attributes
@@ -271,7 +272,8 @@ declare module 'chargebee' {
         | 'faster_payments'
         | 'sepa_instant_transfer'
         | 'klarna_pay_now'
-        | 'online_banking_poland';
+        | 'online_banking_poland'
+        | 'payconiq_by_bancontact';
       reference_id?: string;
       /**
        * @deprecated Please refer API docs to use other attributes

--- a/types/resources/Hierarchy.d.ts
+++ b/types/resources/Hierarchy.d.ts
@@ -7,6 +7,7 @@ declare module 'chargebee' {
     parent_id?: string;
     payment_owner_id: string;
     invoice_owner_id: string;
+    has_children?: boolean;
     children_ids?: string[];
   }
 }

--- a/types/resources/Invoice.d.ts
+++ b/types/resources/Invoice.d.ts
@@ -1216,7 +1216,8 @@ declare module 'chargebee' {
         | 'faster_payments'
         | 'sepa_instant_transfer'
         | 'klarna_pay_now'
-        | 'online_banking_poland';
+        | 'online_banking_poland'
+        | 'payconiq_by_bancontact';
       reference_id?: string;
       /**
        * @deprecated Please refer API docs to use other attributes
@@ -1362,7 +1363,8 @@ declare module 'chargebee' {
         | 'faster_payments'
         | 'sepa_instant_transfer'
         | 'klarna_pay_now'
-        | 'online_banking_poland';
+        | 'online_banking_poland'
+        | 'payconiq_by_bancontact';
       reference_id?: string;
       /**
        * @deprecated Please refer API docs to use other attributes
@@ -1647,7 +1649,13 @@ declare module 'chargebee' {
     }
 
     export interface LineItemRetrieveInputParam {
+      /**
+       * @deprecated Please refer API docs to use other attributes
+       */
       subscription_id?: filter.String;
+      /**
+       * @deprecated Please refer API docs to use other attributes
+       */
       customer_id?: filter.String;
     }
 

--- a/types/resources/PaymentIntent.d.ts
+++ b/types/resources/PaymentIntent.d.ts
@@ -30,7 +30,8 @@ declare module 'chargebee' {
       | 'faster_payments'
       | 'sepa_instant_transfer'
       | 'klarna_pay_now'
-      | 'online_banking_poland';
+      | 'online_banking_poland'
+      | 'payconiq_by_bancontact';
     success_url?: string;
     failure_url?: string;
     created_at: number;
@@ -104,7 +105,8 @@ declare module 'chargebee' {
         | 'faster_payments'
         | 'sepa_instant_transfer'
         | 'klarna_pay_now'
-        | 'online_banking_poland';
+        | 'online_banking_poland'
+        | 'payconiq_by_bancontact';
       id_at_gateway?: string;
       error_code?: string;
       error_text?: string;
@@ -142,7 +144,8 @@ declare module 'chargebee' {
         | 'faster_payments'
         | 'sepa_instant_transfer'
         | 'klarna_pay_now'
-        | 'online_banking_poland';
+        | 'online_banking_poland'
+        | 'payconiq_by_bancontact';
       success_url?: string;
       failure_url?: string;
     }
@@ -170,7 +173,8 @@ declare module 'chargebee' {
         | 'faster_payments'
         | 'sepa_instant_transfer'
         | 'klarna_pay_now'
-        | 'online_banking_poland';
+        | 'online_banking_poland'
+        | 'payconiq_by_bancontact';
       success_url?: string;
       failure_url?: string;
     }

--- a/types/resources/PaymentSource.d.ts
+++ b/types/resources/PaymentSource.d.ts
@@ -452,7 +452,8 @@ declare module 'chargebee' {
         | 'faster_payments'
         | 'sepa_instant_transfer'
         | 'klarna_pay_now'
-        | 'online_banking_poland';
+        | 'online_banking_poland'
+        | 'payconiq_by_bancontact';
       reference_id?: string;
       /**
        * @deprecated Please refer API docs to use other attributes

--- a/types/resources/Purchase.d.ts
+++ b/types/resources/Purchase.d.ts
@@ -38,6 +38,7 @@ declare module 'chargebee' {
     export interface CreateInputParam {
       customer_id: string;
       payment_source_id?: string;
+      replace_primary_payment_source?: boolean;
       invoice_info?: InvoiceInfoCreateInputParam;
       payment_schedule?: PaymentScheduleCreateInputParam;
       statement_descriptor?: StatementDescriptorCreateInputParam;
@@ -96,7 +97,8 @@ declare module 'chargebee' {
         | 'faster_payments'
         | 'sepa_instant_transfer'
         | 'klarna_pay_now'
-        | 'online_banking_poland';
+        | 'online_banking_poland'
+        | 'payconiq_by_bancontact';
       reference_id?: string;
       /**
        * @deprecated Please refer API docs to use other attributes

--- a/types/resources/Quote.d.ts
+++ b/types/resources/Quote.d.ts
@@ -184,6 +184,7 @@ declare module 'chargebee' {
       quote: Quote;
       quoted_subscription?: QuotedSubscription;
       quoted_charge?: QuotedCharge;
+      quoted_ramp?: QuotedRamp;
     }
 
     export interface CreateSubForCustomerQuoteResponse {
@@ -219,21 +220,25 @@ declare module 'chargebee' {
     export interface CreateSubItemsForCustomerQuoteResponse {
       quote: Quote;
       quoted_subscription?: QuotedSubscription;
+      quoted_ramp?: QuotedRamp;
     }
 
     export interface EditCreateSubCustomerQuoteForItemsResponse {
       quote: Quote;
       quoted_subscription?: QuotedSubscription;
+      quoted_ramp?: QuotedRamp;
     }
 
     export interface UpdateSubscriptionQuoteForItemsResponse {
       quote: Quote;
       quoted_subscription?: QuotedSubscription;
+      quoted_ramp?: QuotedRamp;
     }
 
     export interface EditUpdateSubscriptionQuoteForItemsResponse {
       quote: Quote;
       quoted_subscription?: QuotedSubscription;
+      quoted_ramp?: QuotedRamp;
     }
 
     export interface CreateForChargeItemsAndChargesResponse {
@@ -247,7 +252,11 @@ declare module 'chargebee' {
     }
 
     export interface ListResponse {
-      list: { quote: Quote; quoted_subscription?: QuotedSubscription }[];
+      list: {
+        quote: Quote;
+        quoted_subscription?: QuotedSubscription;
+        quoted_ramp?: QuotedRamp;
+      }[];
       next_offset?: string;
     }
 
@@ -260,6 +269,7 @@ declare module 'chargebee' {
       quote: Quote;
       quoted_subscription?: QuotedSubscription;
       quoted_charge?: QuotedCharge;
+      quoted_ramp?: QuotedRamp;
       customer: Customer;
       subscription?: Subscription;
       invoice?: Invoice;
@@ -271,18 +281,21 @@ declare module 'chargebee' {
       quote: Quote;
       quoted_subscription?: QuotedSubscription;
       quoted_charge?: QuotedCharge;
+      quoted_ramp?: QuotedRamp;
     }
 
     export interface ExtendExpiryDateResponse {
       quote: Quote;
       quoted_subscription?: QuotedSubscription;
       quoted_charge?: QuotedCharge;
+      quoted_ramp?: QuotedRamp;
     }
 
     export interface DeleteResponse {
       quote: Quote;
       quoted_subscription?: QuotedSubscription;
       quoted_charge?: QuotedCharge;
+      quoted_ramp?: QuotedRamp;
     }
 
     export interface PdfResponse {

--- a/types/resources/QuotedRamp.d.ts
+++ b/types/resources/QuotedRamp.d.ts
@@ -7,6 +7,7 @@ declare module 'chargebee' {
     line_items?: QuotedRamp.LineItem[];
     discounts?: QuotedRamp.Discount[];
     item_tiers?: QuotedRamp.ItemTier[];
+    coupon_applicability_mappings?: QuotedRamp.CouponApplicabilityMapping[];
   }
 
   export namespace QuotedRamp {
@@ -37,16 +38,10 @@ declare module 'chargebee' {
       start_date?: number;
       end_date?: number;
       ramp_tier_id?: string;
-      discount_amount?: number;
-      md_discount_amount?: string;
-      item_level_discount_amount?: number;
-      md_item_level_discount_amount?: string;
       discount_per_billing_cycle?: number;
       discount_per_billing_cycle_in_decimal?: string;
       item_level_discount_per_billing_cycle?: number;
       item_level_discount_per_billing_cycle_in_decimal?: string;
-      net_amount?: number;
-      md_net_amount?: string;
       amount_per_billing_cycle?: number;
       amount_per_billing_cycle_in_decimal?: string;
       net_amount_per_billing_cycle?: number;
@@ -54,7 +49,6 @@ declare module 'chargebee' {
     }
     export interface Discount {
       id: string;
-      name: string;
       invoice_name?: string;
       type: 'fixed_amount' | 'percentage';
       percentage?: number;
@@ -70,7 +64,6 @@ declare module 'chargebee' {
       period_unit?: 'day' | 'week' | 'month' | 'year';
       included_in_mrr: boolean;
       apply_on: 'invoice_amount' | 'specific_item_price';
-      apply_on_item_type?: 'plan' | 'addon' | 'charge';
       item_price_id?: string;
       created_at: number;
       updated_at?: number;
@@ -86,6 +79,12 @@ declare module 'chargebee' {
       ending_unit_in_decimal?: string;
       price_in_decimal?: string;
       ramp_tier_id?: string;
+      pricing_type?: 'per_unit' | 'flat_fee' | 'package';
+      package_size?: number;
+    }
+    export interface CouponApplicabilityMapping {
+      coupon_id?: string;
+      applicable_item_price_ids?: string[];
     }
     // REQUEST PARAMS
     //---------------

--- a/types/resources/RecordedPurchase.d.ts
+++ b/types/resources/RecordedPurchase.d.ts
@@ -51,6 +51,7 @@ declare module 'chargebee' {
       customer?: CustomerCreateInputParam;
       apple_app_store?: AppleAppStoreCreateInputParam;
       google_play_store?: GooglePlayStoreCreateInputParam;
+      omnichannel_subscription?: OmnichannelSubscriptionCreateInputParam;
     }
     export interface CustomerCreateInputParam {
       id: string;
@@ -62,6 +63,9 @@ declare module 'chargebee' {
       transaction_id?: string;
       receipt?: string;
       product_id?: string;
+    }
+    export interface OmnichannelSubscriptionCreateInputParam {
+      id?: string;
     }
   }
 }

--- a/types/resources/Subscription.d.ts
+++ b/types/resources/Subscription.d.ts
@@ -896,6 +896,8 @@ declare module 'chargebee' {
     }
     export interface RemoveScheduledCancellationInputParam {
       billing_cycles?: number;
+      contract_term_billing_cycle_on_renewal?: number;
+      contract_term?: ContractTermRemoveScheduledCancellationInputParam;
     }
     export interface RemoveCouponsInputParam {
       coupon_ids?: string[];
@@ -1397,7 +1399,8 @@ declare module 'chargebee' {
         | 'faster_payments'
         | 'sepa_instant_transfer'
         | 'klarna_pay_now'
-        | 'online_banking_poland';
+        | 'online_banking_poland'
+        | 'payconiq_by_bancontact';
       reference_id?: string;
       /**
        * @deprecated Please refer API docs to use other attributes
@@ -1524,7 +1527,8 @@ declare module 'chargebee' {
         | 'faster_payments'
         | 'sepa_instant_transfer'
         | 'klarna_pay_now'
-        | 'online_banking_poland';
+        | 'online_banking_poland'
+        | 'payconiq_by_bancontact';
       reference_id?: string;
       /**
        * @deprecated Please refer API docs to use other attributes
@@ -1618,7 +1622,8 @@ declare module 'chargebee' {
         | 'faster_payments'
         | 'sepa_instant_transfer'
         | 'klarna_pay_now'
-        | 'online_banking_poland';
+        | 'online_banking_poland'
+        | 'payconiq_by_bancontact';
       reference_id?: string;
       /**
        * @deprecated Please refer API docs to use other attributes
@@ -1676,6 +1681,11 @@ declare module 'chargebee' {
       pricing_type?: PricingTypeEnum;
       package_size?: number;
     }
+    export interface ContractTermRemoveScheduledCancellationInputParam {
+      action_at_term_end?: 'renew' | 'evergreen' | 'cancel';
+      cancellation_cutoff_period?: number;
+    }
+
     export interface BillingAddressUpdateInputParam {
       first_name?: string;
       last_name?: string;
@@ -1761,7 +1771,8 @@ declare module 'chargebee' {
         | 'faster_payments'
         | 'sepa_instant_transfer'
         | 'klarna_pay_now'
-        | 'online_banking_poland';
+        | 'online_banking_poland'
+        | 'payconiq_by_bancontact';
       reference_id?: string;
       /**
        * @deprecated Please refer API docs to use other attributes
@@ -1924,7 +1935,8 @@ declare module 'chargebee' {
         | 'faster_payments'
         | 'sepa_instant_transfer'
         | 'klarna_pay_now'
-        | 'online_banking_poland';
+        | 'online_banking_poland'
+        | 'payconiq_by_bancontact';
       reference_id?: string;
       /**
        * @deprecated Please refer API docs to use other attributes
@@ -2042,7 +2054,8 @@ declare module 'chargebee' {
         | 'faster_payments'
         | 'sepa_instant_transfer'
         | 'klarna_pay_now'
-        | 'online_banking_poland';
+        | 'online_banking_poland'
+        | 'payconiq_by_bancontact';
       reference_id?: string;
       /**
        * @deprecated Please refer API docs to use other attributes
@@ -2463,7 +2476,8 @@ declare module 'chargebee' {
         | 'faster_payments'
         | 'sepa_instant_transfer'
         | 'klarna_pay_now'
-        | 'online_banking_poland';
+        | 'online_banking_poland'
+        | 'payconiq_by_bancontact';
       reference_id?: string;
       /**
        * @deprecated Please refer API docs to use other attributes


### PR DESCRIPTION
## Release PR

SDK: node
Version: 3.11.0

This PR contains the latest changes from cb-client-libs/node.

### v3.11.0 (2025-07-18) 
* * * 

### New Resources: 
* BillingConfiguration has been added. 
* Brand has been added. 

### New Attributes: 
* has_children has been added to Hierarchy
* coupon_applicability_mappings has been added to QuotedRamp.

### New Endpoint:
* listHierarchyDetail has been added to Customer.

### New Input parameters: 
* change_reason children has been added to Entitlement#CreateRequest.
* entitlements[apply_grandfathering] has been added to Entitlement#CreateRequest.
* replace_primary_payment_source has been added to Purchase#CreateRequest.
* omnichannel_subscription has been added to RecordedPurchase#CreateRequest.
* contract_term has been added to Subscription#RemoveScheduledCancellationRequest.
* contract_term_billing_cycle_on_renewal has been added to Subscription#RemoveScheduledCancellationRequest.

### New Enums: 
* payconiq_by_bancontact has been added to PaymentMethodType.
* solidgate has been added to Gateway.
* solidgate has been added to PaymentMethod.