### PR TITLE
Release node SDK v3.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### v3.11.1 (2025-07-18) 
+* * * 
+
+### Bug Fixes: 
+* Resolved a module dependency issue that was causing runtime failures in the Edge environment. 
+
+
 ### v3.11.0 (2025-07-18) 
 * * * 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chargebee",
-  "version": "3.10.0",
+  "version": "3.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chargebee",
-      "version": "3.10.0",
+      "version": "3.11.1",
       "devDependencies": {
         "@types/node": "20.0.0",
         "prettier": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chargebee",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "A library for integrating with Chargebee.",
   "scripts": {
     "prepack": "npm install && npm run build",

--- a/src/chargebee.esm.ts
+++ b/src/chargebee.esm.ts
@@ -1,11 +1,8 @@
 import { CreateChargebee } from './createChargebee.js';
-import { NodeHttpClient } from './net/NodeClient.js';
 import { FetchHttpClient } from './net/FetchClient.js';
 
 //@ts-ignore
-const httpClient = !globalThis.fetch
-  ? new NodeHttpClient()
-  : new FetchHttpClient();
+const httpClient = new FetchHttpClient();
 const Chargebee = CreateChargebee(httpClient);
 
 export default Chargebee;

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -9,7 +9,7 @@ export const Environment = {
   hostSuffix: '.chargebee.com',
   apiPath: '/api/v2',
   timeout: DEFAULT_TIME_OUT,
-  clientVersion: 'v3.11.0',
+  clientVersion: 'v3.11.1',
   port: DEFAULT_PORT,
   timemachineWaitInMillis: DEFAULT_TIME_MACHINE_WAIT,
   exportWaitInMillis: DEFAULT_EXPORT_WAIT,

--- a/src/util.ts
+++ b/src/util.ts
@@ -271,24 +271,10 @@ export function log(
   console.debug(logLine);
 }
 
-import { randomBytes } from 'crypto';
-
 export function generateUUIDv4(): string {
-  const bytes: Buffer = randomBytes(16);
-
-  // Set version to 4 (UUIDv4)
-  bytes[6] = (bytes[6] & 0x0f) | 0x40;
-
-  // Set variant to 10xxxxxx
-  bytes[8] = (bytes[8] & 0x3f) | 0x80;
-
-  const hex = bytes.toString('hex');
-
-  return [
-    hex.slice(0, 8),
-    hex.slice(8, 12),
-    hex.slice(12, 16),
-    hex.slice(16, 20),
-    hex.slice(20),
-  ].join('-');
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+      const r = (Math.random() * 16) | 0;
+      const v = c === 'x' ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
 }


### PR DESCRIPTION
## Release PR

SDK: node
Version: 3.11.1

This PR contains the latest changes from cb-client-libs/node.

### v3.11.1 (2025-07-18) 
* * * 

### Bug Fixes: 
* Resolved a module dependency issue that was causing runtime failures in the Edge environment. 