### PR TITLE
Fix an issue where retried GET requests are retried without query parameters

### DIFF
--- a/src/RequestWrapper.ts
+++ b/src/RequestWrapper.ts
@@ -67,7 +67,7 @@ export class RequestWrapper {
     };
 
     const urlIdParam: string = this.apiCall.hasIdInUrl ? this.args[0] : null;
-    let params: JSONValue = this.apiCall.hasIdInUrl
+    const params: JSONValue = this.apiCall.hasIdInUrl
       ? this.args[1]
       : this.args[0];
     let headers = this.apiCall.hasIdInUrl ? this.args[2] : this.args[1];
@@ -92,22 +92,30 @@ export class RequestWrapper {
         urlIdParam,
       );
 
-      if (typeof params === 'undefined' || params === null) {
-        params = {};
+      let requestParams: JSONValue = params;
+
+      if (typeof requestParams === 'undefined' || requestParams === null) {
+        requestParams = {};
       }
 
       if (this.apiCall.httpMethod === 'GET') {
         const queryParam = this.apiCall.isListReq
-          ? encodeListParams(serialize(params))
-          : encodeParams(serialize(params));
+          ? encodeListParams(serialize(requestParams))
+          : encodeParams(serialize(requestParams));
         path += '?' + queryParam;
-        params = {};
+        requestParams = {};
       }
 
       const jsonKeys = this.apiCall.jsonKeys;
       const data: string = this.apiCall.isJsonRequest
-        ? JSON.stringify(params)
-        : encodeParams(params, undefined, undefined, undefined, jsonKeys);
+        ? JSON.stringify(requestParams)
+        : encodeParams(
+            requestParams,
+            undefined,
+            undefined,
+            undefined,
+            jsonKeys,
+          );
 
       const requestHeaders: RequestHeaders = { ...this.httpHeaders };
       if (data.length) {


### PR DESCRIPTION
### Description
When `retryConfig.enabled = true`, if a GET request is retried, it will be done without query parameters

For example, if you do `chargebee.subscription.list({ "customer_id[is]": "xxx" })` and the first attempt fails, all retries will behave as if you did `chargebee.subscription.list()`

This can be very surprising

The bug is here: https://github.com/chargebee/chargebee-node/blob/5d368515075c13c74a62575d3d3a8f02810f8dc8/src/RequestWrapper.ts#L104

### Related Issues
None

### Additional Information
None