### PR TITLE
Releasing v3.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### v3.15.1 (2025-10-29)
+* * * 
+
+### Bug Fixes:
+* Resolves(#88): an issue where requests made with the GET methods incorrectly included a request body, causing the Request interface to throw an error. 
+
 ### v3.15.0 (2025-10-28)
 * * * 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chargebee",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chargebee",
-      "version": "3.15.0",
+      "version": "3.15.1",
       "devDependencies": {
         "@types/node": "20.0.0",
         "prettier": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chargebee",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "description": "A library for integrating with Chargebee.",
   "scripts": {
     "prepack": "npm install && npm run build",

--- a/src/RequestWrapper.ts
+++ b/src/RequestWrapper.ts
@@ -140,7 +140,7 @@ export class RequestWrapper {
       );
       const request: Request = new Request(url, {
         method: this.apiCall.httpMethod,
-        body: data ?? undefined,
+        body: data ? data : undefined,
         headers: this._createHeaders(requestHeaders),
       });
       const resp: Response = await this.envArg.httpClient.makeApiRequest(

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -9,7 +9,7 @@ export const Environment = {
   hostSuffix: '.chargebee.com',
   apiPath: '/api/v2',
   timeout: DEFAULT_TIME_OUT,
-  clientVersion: 'v3.15.0',
+  clientVersion: 'v3.15.1',
   port: DEFAULT_PORT,
   timemachineWaitInMillis: DEFAULT_TIME_MACHINE_WAIT,
   exportWaitInMillis: DEFAULT_EXPORT_WAIT,


### PR DESCRIPTION
### v3.15.1 (2025-10-29)
* * * 

### Bug Fixes:
* Resolves(#88): an issue where requests made with the GET methods incorrectly included a request body, causing the Request interface to throw an error. 